### PR TITLE
Feat/adiciona paginacao busca voos

### DIFF
--- a/src/controller/FlightController.ts
+++ b/src/controller/FlightController.ts
@@ -8,7 +8,10 @@ export class FlightController {
 
     async getAllFlights(req: Request, res: Response): Promise<any> {
         try {
-            const flights = await this.flightService.getAllFlights();
+            const page = req.query.page ? parseInt(req.query.page as string) : undefined;
+            const pageSize = req.query.pageSize ? parseInt(req.query.pageSize as string) : undefined;
+
+            const flights = await this.flightService.getAllFlights(page, pageSize);
             res.status(200).json(flights);
         } catch (error) {
             console.error("Error fetching flights:", error);

--- a/src/repositories/FlightRepository.ts
+++ b/src/repositories/FlightRepository.ts
@@ -6,8 +6,15 @@ import { Flight } from "../domain/Flight";
 export class FlightRepository {
     private repository: Repository<FlightAggregate> = AppDataSource.getRepository(FlightAggregate);
 
-    async getAll(): Promise<Flight[]> {
-        const flightAggregates = await this.repository.find();
+    async getAll(page: number | undefined, pageSize: number | undefined): Promise<Flight[]> {
+        const options: any = {};
+
+        if (pageSize !== undefined && pageSize > 0) {
+            options.take = pageSize;
+            options.skip = (page && page > 0) ? (page - 1) * pageSize : 0;
+        }
+        
+        const flightAggregates = await this.repository.find(options);
         return flightAggregates.map(flight => flight.toDomain());
     }
 }

--- a/src/service/flight/FlightService.ts
+++ b/src/service/flight/FlightService.ts
@@ -7,8 +7,8 @@ export class FlightService {
         private flightRepository: FlightRepository
     ) {}
 
-    async getAllFlights(): Promise<FlightDto[]> {
-        const flights = await this.flightRepository.getAll();
+    async getAllFlights(page: number | undefined, pageSize: number | undefined): Promise<FlightDto[]> {
+        const flights = await this.flightRepository.getAll(page, pageSize);
         if (flights.length === 0) {
             return [];
         }


### PR DESCRIPTION
##  \[Feature] Paginação na Listagem de Voos

### Descrição

Esta PR adiciona suporte à **paginação** na rota `GET /api/flights`, permitindo consultar os voos de forma paginada utilizando os parâmetros `page` e `pageSize`.

---

###  **Alterações realizadas**

#### Controller (`FlightController.ts`)

* Atualizado o método `getAllFlights` para extrair `page` e `pageSize` dos parâmetros de query da requisição.
* Os parâmetros são convertidos para `number` e passados ao service.

#### Service (`FlightService.ts`)

* Atualizado o método `getAllFlights` para aceitar os parâmetros `page` e `pageSize` e repassá-los ao repositório.

#### Repository (`FlightRepository.ts`)

* Implementada lógica de paginação utilizando `skip` e `take` com base em `page` e `pageSize`.
* Caso `pageSize` não seja informado ou inválido, retorna todos os registros (comportamento anterior).

---

### **Exemplo de uso**

Requisição:

```
GET /api/flights?page=2&pageSize=10
```

Comportamento:

* Retorna os voos da segunda página, com 10 voos por página (do voo 11 ao 20).

---

### **Consideração**

* Os parâmetros são opcionais. Caso não sejam informados, todos os voos serão retornados como no comportamento anterior.

---