### PR TITLE
feat/adiona-funcionalidade-remover-voos-favoritos

### DIFF
--- a/src/controller/BookmarkController.ts
+++ b/src/controller/BookmarkController.ts
@@ -44,7 +44,7 @@ export class BookmarkController {
     }
 
     async unmarkFlightAsFavorite(req: Request, res: Response): Promise<void> {
-        const { flightNumber } = req.body;
+        const { flightNumber } = req.params;
 
         if (typeof flightNumber !== 'string' || flightNumber.trim().length === 0) {
             res.status(400).json({ msg: "Número do voo é obrigatório" });
@@ -56,7 +56,7 @@ export class BookmarkController {
             res.status(200).json({ msg: "Voo desmarcado como favorito com sucesso" });
         } catch (error) {
             if (error instanceof Error) {
-                if (error.message === "Voo não está marcado como favorito") {
+                if (error.message === "Voo não está marcado como favorito.") {
                     res.status(404).json({ msg: error.message });
                 }
             } else {

--- a/src/controller/BookmarkController.ts
+++ b/src/controller/BookmarkController.ts
@@ -9,28 +9,50 @@ export class BookmarkController {
     }
 
     async markFlightAsFavorite(req: Request, res: Response): Promise<void> {
-    const { flightNumber } = req.body;
+        const { flightNumber } = req.body;
 
-    if (typeof flightNumber !== 'string' || flightNumber.trim().length === 0) {
-        res.status(400).json({ msg: "Número do voo é obrigatório" });
-        return;
-    }
+        if (typeof flightNumber !== 'string' || flightNumber.trim().length === 0) {
+            res.status(400).json({ msg: "Número do voo é obrigatório" });
+            return;
+        }
 
-    try {
-        await this.bookmarkService.markFlightAsFavorite(flightNumber.trim());
-        res.status(200).json({ msg: "Voo marcado como favorito com sucesso" });
-    } catch (error) {
-        if (error instanceof Error) {
-            if (error.message === "Voo não encontrado") {
-                res.status(404).json({ msg: error.message });
-            } else if (error.message === "Voo já está marcado como favorito") {
-                res.status(409).json({ msg: error.message });
+        try {
+            await this.bookmarkService.markFlightAsFavorite(flightNumber.trim());
+            res.status(200).json({ msg: "Voo marcado como favorito com sucesso" });
+        } catch (error) {
+            if (error instanceof Error) {
+                if (error.message === "Voo não encontrado") {
+                    res.status(404).json({ msg: error.message });
+                } else if (error.message === "Voo já está marcado como favorito") {
+                    res.status(409).json({ msg: error.message });
+                } else {
+                    res.status(400).json({ msg: error.message });
+                }
             } else {
-                res.status(400).json({ msg: error.message });
+                res.status(500).json({ msg: "Erro interno do servidor" });
             }
-        } else {
-            res.status(500).json({ msg: "Erro interno do servidor" });
         }
     }
-}
+
+    async unmarkFlightAsFavorite(req: Request, res: Response): Promise<void> {
+        const { flightNumber } = req.body;
+
+        if (typeof flightNumber !== 'string' || flightNumber.trim().length === 0) {
+            res.status(400).json({ msg: "Número do voo é obrigatório" });
+            return;
+        }
+
+        try {
+            await this.bookmarkService.unmarkFlightAsFavorite(flightNumber.trim());
+            res.status(200).json({ msg: "Voo desmarcado como favorito com sucesso" });
+        } catch (error) {
+            if (error instanceof Error) {
+                if (error.message === "Voo não está marcado como favorito") {
+                    res.status(404).json({ msg: error.message });
+                }
+            } else {
+                res.status(500).json({ msg: "Erro interno do servidor" });
+            }
+        }
+    }
 }

--- a/src/repositories/BookmarkRepository.ts
+++ b/src/repositories/BookmarkRepository.ts
@@ -10,4 +10,8 @@ export class BookmarkRepository {
     async hasFlightAsFavorite(flightNumber: string): Promise<boolean> {
         return this.cache.has(flightNumber);
     }
+
+    async unmarkFlightAsFavorite(flightNumber: string): Promise<void> {
+        this.cache.delete(flightNumber);
+    }
 }

--- a/src/repositories/BookmarkRepository.ts
+++ b/src/repositories/BookmarkRepository.ts
@@ -16,6 +16,10 @@ export class BookmarkRepository {
     }
 
     async unmarkFlightAsFavorite(flightNumber: string): Promise<void> {
-        this.cache.delete(flightNumber);
+        for (const flight of this.cache) {
+            if (flight.flightNumber === flightNumber) {
+                this.cache.delete(flight);
+            }
+        }
     }
 }

--- a/src/routes/bookmark.routes.ts
+++ b/src/routes/bookmark.routes.ts
@@ -18,6 +18,8 @@ router.post("/", (req: Request, res: Response) => {
     controller.markFlightAsFavorite(req, res)
 });
 
-router.delete("/:flightNumber", (req: Request, res: Response) => {})
+router.delete("/:flightNumber", (req: Request, res: Response) => {
+    controller.unmarkFlightAsFavorite(req, res);
+});
 
 export default router;

--- a/src/service/bookmark/BookmarkService.ts
+++ b/src/service/bookmark/BookmarkService.ts
@@ -22,4 +22,12 @@ export class BookmarkService {
 
         await this.bookmarkRepository.markFlightAsFavorite(flight);
     }
+
+    async unmarkFlightAsFavorite(flightNumber: string): Promise<void> {
+        if (!(await this.bookmarkRepository.hasFlightAsFavorite(flightNumber))) {
+            throw new Error("Voo não está marcado como favorito");
+        }
+
+        await this.bookmarkRepository.unmarkFlightAsFavorite(flightNumber)
+    }
 }

--- a/src/service/bookmark/BookmarkService.ts
+++ b/src/service/bookmark/BookmarkService.ts
@@ -31,7 +31,7 @@ export class BookmarkService {
 
     async unmarkFlightAsFavorite(flightNumber: string): Promise<void> {
         if (!(await this.bookmarkRepository.hasFlightAsFavorite(flightNumber))) {
-            throw new Error("Voo não está marcado como favorito");
+            throw new Error("Voo não está marcado como favorito.");
         }
 
         await this.bookmarkRepository.unmarkFlightAsFavorite(flightNumber)


### PR DESCRIPTION
### \[FEATURE] Desmarcar Voos Favoritos

**Descrição:**
Adiciona a funcionalidade de remoção de voos da lista de favoritos.

---

###  Alterações incluídas:

* Criação do método `unmarkFlightAsFavorite` no `BookmarkController`:

    * Recebe o `flightNumber` via parâmetro de rota.
    * Retorna status `200` ao desfavoritar.
    * Retorna `404` caso o voo não esteja marcado como favorito.
* Implementação do método `unmarkFlightAsFavorite` no `BookmarkService` com validação de existência do favorito.
* Ajuste no `BookmarkRepository`:

    * Método `unmarkFlightAsFavorite` que remove o voo do cache interno com base no `flightNumber`.
* Atualização da rota `DELETE /api/bookmarks/:flightNumber` para permitir a remoção do favorito.

---

### Comportamento esperado:

* `DELETE /api/bookmarks/:flightNumber` remove o voo da lista de favoritos, se existir.
* Retorna `200 OK` ao sucesso.
* Retorna `404 Not Found` se o voo não estiver na lista de favoritos.
* Proteção contra inputs inválidos no parâmetro.

---

### Observações Técnicas:

* O armazenamento dos favoritos permanece em memória (`Set<Flight>`), adequado para ambiente de desenvolvimento ou protótipo.
* O loop de remoção percorre a coleção para identificar o voo pelo `flightNumber`.
* Possível otimização futura: migrar a estrutura para `Map<string, Flight>` e facilitar buscas/remoções por chave direta.
---
