### PR TITLE
Fix/corrige retorno voos paginados

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,12 +9,14 @@
       "version": "1.0.0",
       "license": "ISC",
       "dependencies": {
+        "cors": "^2.8.5",
         "express": "^5.1.0",
         "pg": "^8.16.3",
         "reflect-metadata": "^0.2.2",
         "typeorm": "^0.3.25"
       },
       "devDependencies": {
+        "@types/cors": "^2.8.19",
         "@types/express": "^5.0.3",
         "@types/node": "^24.0.6",
         "nodemon": "^3.1.10",
@@ -139,6 +141,16 @@
       "version": "3.4.38",
       "resolved": "https://registry.npmjs.org/@types/connect/-/connect-3.4.38.tgz",
       "integrity": "sha512-K6uROf1LD88uDQqJCktA4yzL1YYAK6NgfsI0v/mTgyPKWsX1CnJ0XPSDhViejru1GcRkLWb8RlzFYJRqGUbaug==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
+    "node_modules/@types/cors": {
+      "version": "2.8.19",
+      "resolved": "https://registry.npmjs.org/@types/cors/-/cors-2.8.19.tgz",
+      "integrity": "sha512-mFNylyeyqN93lfe/9CSxOGREz8cpzAhH+E93xJ4xWQf62V8sQ/24reV2nyzUWM6H6Xji+GGHpkbLe7pVoUEskg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -650,6 +662,19 @@
       "license": "MIT",
       "engines": {
         "node": ">=6.6.0"
+      }
+    },
+    "node_modules/cors": {
+      "version": "2.8.5",
+      "resolved": "https://registry.npmjs.org/cors/-/cors-2.8.5.tgz",
+      "integrity": "sha512-KIHbLJqu73RGr/hnbrO9uBeixNGuvSQjul/jdFvS/KFSIH1hWVd1ng7zOHx+YrEfInLG7q4n6GHQ9cDtxv/P6g==",
+      "license": "MIT",
+      "dependencies": {
+        "object-assign": "^4",
+        "vary": "^1"
+      },
+      "engines": {
+        "node": ">= 0.10"
       }
     },
     "node_modules/create-require": {
@@ -1413,6 +1438,15 @@
       "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
       "integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==",
       "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/object-assign": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+      "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"

--- a/package.json
+++ b/package.json
@@ -12,12 +12,14 @@
   "license": "ISC",
   "description": "",
   "dependencies": {
+    "cors": "^2.8.5",
     "express": "^5.1.0",
     "pg": "^8.16.3",
     "reflect-metadata": "^0.2.2",
     "typeorm": "^0.3.25"
   },
   "devDependencies": {
+    "@types/cors": "^2.8.19",
     "@types/express": "^5.0.3",
     "@types/node": "^24.0.6",
     "nodemon": "^3.1.10",

--- a/src/app.ts
+++ b/src/app.ts
@@ -1,5 +1,6 @@
 import express, { Express } from "express";
 import { router } from "./routes";
+import cors from "cors";
 
 export default class App {
     public express: Express;
@@ -12,6 +13,9 @@ export default class App {
 
     private config(): void {
         this.express.use(express.json());
+        this.express.use(cors({
+            origin: "http://localhost:3000"
+        }))
     }
 
     private routes(): void {

--- a/src/repositories/FlightRepository.ts
+++ b/src/repositories/FlightRepository.ts
@@ -1,4 +1,4 @@
-import { Repository } from "typeorm";
+import { Between, Repository } from "typeorm";
 import { FlightAggregate } from "../aggregates/FlightAgregate";
 import { AppDataSource } from "../config/database/data-source";
 import { Flight } from "../domain/Flight";
@@ -6,7 +6,7 @@ import { Flight } from "../domain/Flight";
 export class FlightRepository {
     private repository: Repository<FlightAggregate> = AppDataSource.getRepository(FlightAggregate);
 
-    async getAll(page: number | undefined, pageSize: number | undefined): Promise<Flight[]> {
+    async getAll(page: number | undefined, pageSize: number | undefined): Promise<{ data: Flight[], total: number }> {
         const options: any = {};
 
         if (pageSize !== undefined && pageSize > 0) {
@@ -14,8 +14,9 @@ export class FlightRepository {
             options.skip = (page && page > 0) ? (page - 1) * pageSize : 0;
         }
         
-        const flightAggregates = await this.repository.find(options);
-        return flightAggregates.map(flight => flight.toDomain());
+        const [flightAggregates, total] = await this.repository.findAndCount(options);
+        const flights = flightAggregates.map(flight => flight.toDomain()); 
+        return { data: flights, total};
     }
 
     async getFlightByNumber(flightNumber: string): Promise<Flight | null> {
@@ -37,7 +38,13 @@ export class FlightRepository {
     ): Promise<Flight[]> {
         const where: Record<string, any> = { origin, destination };
         if (departure) {
-            where.departure = departure;
+            const startOfDay = new Date(departure);
+            startOfDay.setHours(0, 0, 0, 0);
+
+            const endOfDay = new Date(departure);
+            endOfDay.setHours(23, 59, 59, 999);
+
+            where.departure = Between(startOfDay, endOfDay);
         }
 
         const flightAggregates = await this.repository.find({ where });

--- a/src/server.ts
+++ b/src/server.ts
@@ -3,7 +3,7 @@ import {AppDataSource} from "./config/database/data-source";
 import {seedFlight} from "./seed";
 
 const app = new App();
-const port: number = 3000;
+const port: number = 3001;
 
 AppDataSource.initialize()
     .then(async () => {

--- a/src/service/flight/FlightService.ts
+++ b/src/service/flight/FlightService.ts
@@ -8,12 +8,13 @@ export class FlightService {
         private flightRepository: FlightRepository
     ) {}
 
-    async getAllFlights(page: number | undefined, pageSize: number | undefined): Promise<FlightDto[]> {
+    async getAllFlights(page: number | undefined, pageSize: number | undefined): Promise<{ data: FlightDto[], total: number }> {
         const flights = await this.flightRepository.getAll(page, pageSize);
-        if (flights.length === 0) {
-            return [];
+        if (flights.data.length === 0) {
+            return { data: [], total: flights.total };
         }
-        return FlightDto.fromDomainList(flights);
+        const flightDtos = FlightDto.fromDomainList(flights.data);
+        return { data: flightDtos, total: flights.total };
     }
 
     async getFlightByOriginDestinationAndDeparture(findFlightDto: FindFlightDto): Promise<FlightDto[]> {
@@ -21,9 +22,9 @@ export class FlightService {
         const currentDate = new Date();
         currentDate.setMilliseconds(0);
 
-        if (flightDate && flightDate.getTime() < currentDate.getTime()) {
-            throw new Error("A data de partida não pode ser no passado.");
-        }
+        // if (flightDate && flightDate.getTime() < currentDate.getTime()) {
+        //     throw new Error("A data de partida não pode ser no passado.");
+        // }
         
         const flights: Flight[] | null = await this.flightRepository.getFlightByOriginDestinationAndDeparture(
             findFlightDto.origin,


### PR DESCRIPTION
### [Update]: Configuração CORS, paginação e filtro por data na API de voos

**O que foi feito:**

* Adicionada a dependência `cors` e seu tipo para habilitar CORS no backend.
* Configurado middleware CORS para permitir requisições do frontend (`http://localhost:3000`).
* Alterada a porta do servidor para `3001` para evitar conflito com o frontend.
* Atualizado `FlightRepository` para retornar resultados paginados com contagem total (`findAndCount`).
* Implementada paginação e envio do total de itens na resposta do serviço e repositório de voos.
* Ajustado filtro de busca por data de partida para considerar o intervalo completo do dia (00:00 a 23:59:59), usando `Between` do TypeORM.
* Comentada validação que bloqueava buscas com data no passado, facilitando testes e flexibilidade.
